### PR TITLE
Add research: NFRs for reliability & transparency

### DIFF
--- a/docs/Research/nfr-reliability-transparency.adoc
+++ b/docs/Research/nfr-reliability-transparency.adoc
@@ -1,0 +1,60 @@
+= Non-Functional Requirements (NFRs) for Reliability & Transparency
+
+== Purpose
+
+This section defines Non-Functional Requirements (NFRs) for Tu Deporte Aquí focused on reliability, transparency, and fault tolerance. These NFRs establish expectations that can be validated through future testing milestones.
+
+== NFRs (Phase 1)
+
+=== NFR-1: Availability Transparency (Service Status)
+The system shall clearly communicate when core sports data features are unavailable or degraded (e.g., “Data temporarily unavailable” or “Limited updates available”), instead of failing silently.
+
+Observable/Measurable: A visible status message is shown when data cannot be retrieved or displayed.
+
+=== NFR-2: Timestamp Visibility (Freshness)
+The system shall display a “last updated” timestamp for scores/standings/events whenever data is shown to the user.
+
+Observable/Measurable: Timestamp appears on every page/section where sports data is presented.
+
+=== NFR-3: Data Staleness Threshold
+The system shall flag data as “stale” when the last update exceeds a defined threshold.
+
+Default Phase 1 threshold (initial): 30 minutes for live game scores, 24 hours for standings, 24 hours for schedules/news.
+
+Observable/Measurable: A “stale” indicator appears once the threshold is exceeded.
+
+=== NFR-4: Conflict Disclosure (Multiple Sources)
+When multiple sources provide conflicting values for the same data item (e.g., two different scores), the system shall either:
+(a) mark the item as “conflicting,” or
+(b) present both values with source attribution,
+instead of choosing one silently.
+
+Observable/Measurable: Conflicting items show an explicit “conflict” indicator and/or show both values with sources.
+
+=== NFR-5: Graceful Degradation
+If one or more data sources fail, the system shall continue operating using remaining sources and display partial results, while indicating that coverage is incomplete.
+
+Observable/Measurable: The system still loads and shows partial data with a “partial coverage” notice.
+
+=== NFR-6: No Silent Failures
+The system shall not present missing data as if it were valid (e.g., empty score fields without explanation). Missing values shall be replaced by an explicit placeholder message (e.g., “Not reported yet”).
+
+Observable/Measurable: Missing values always show a clear placeholder or message.
+
+=== NFR-7: Reliability Logging Requirement (Internal)
+The system shall record basic retrieval outcomes per source (success, timeout, invalid format, conflict detected) to support future reliability testing and debugging.
+
+Observable/Measurable: Logs exist (local or server logs) showing retrieval outcome events.
+
+=== NFR-8: Consistent User Messaging
+The system shall use consistent terminology for reliability states across the application (e.g., “unverified,” “stale,” “conflicting,” “partial coverage”), aligned with the project glossary.
+
+Observable/Measurable: Same terms appear consistently across pages for the same condition.
+
+== Notes for Future Testing
+
+These NFRs can be tested in future milestones using:
+* simulated source failures (timeouts, 404s, malformed payloads),
+* conflicting source values,
+* delayed updates (staleness thresholds),
+* load/stress scenarios to validate user-facing degradation behavior.


### PR DESCRIPTION
Related to Issue #46

Adds an AsciiDoc research document under docs/research/ defining measurable NFRs for reliability, transparency, and fault tolerance.