### PR TITLE
docs: Add cover page

### DIFF
--- a/docs/00-cover-page.adoc
+++ b/docs/00-cover-page.adoc
@@ -1,0 +1,17 @@
+// Cover Page
+:title-page:
+
+[align="center"]
+= Tu Deporte Aquí Project Documentation
+
+[align="center"]
+**Course:** INSO 4117 - Software Reliability Testing +
+**Semester:** Spring 2026 +
+**Professor:** Marko Schütz-Schmuck
+
+[align="center"]
+**Repository:** https://github.com/uprm-inso4117-2025-2026-s2/semester-project-tu-deporte-aqui +
+**Milestone:** Milestone Number #2 +
+**Date:** March 12, 2026
+
+<<<

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3,6 +3,8 @@
 :toc:
 :toclevels: 4
 
+include::00-cover-page.adoc[]
+
 == 1 Informative part
 include::01-informative/01-01-team.adoc[]
 === 1.2 Current situation, needs, ideas


### PR DESCRIPTION
## Summary

Adds a cover page to the project documentation to improve presentation and make the document easier to identify.

## Changes

- Added `00-cover-page.adoc` with core project information  
- Included the cover page at the start of `docs/index.adoc`

## Impact

Improves documentation structure and presentation without affecting existing content.