### PR TITLE
Refactor BDD reliability terminology and glossary

### DIFF
--- a/docs/Research/project-glossary.adoc
+++ b/docs/Research/project-glossary.adoc
@@ -59,3 +59,30 @@ All teams must use these terms consistently across:
 * User-facing messaging
 
 Terminology must align with the project’s reliability-first philosophy and support transparency in data quality.
+
+== Reliability Terms for BDD Scenarios
+
+[cols="1,3,3",options="header"]
+|===
+| Canonical term | Meaning | Example usage in a scenario
+
+| stale
+| Data is older than the freshness threshold and may no longer match the current event state.
+| `Then Sebastian should see a "Stale" badge next to the score`
+
+| provisional
+| Data is shown for now while waiting for confirmation from a higher-authority source.
+| `Then the score is considered provisional`
+
+| conflicting reports
+| Two or more sources provide different values for the same field or event.
+| `Then conflicting reports exist between the newspaper and the league`
+
+| partial data
+| Only part of the expected data is available because one or more sources are unavailable or incomplete.
+| `And the system should set a "partial data" flag for affected entities`
+
+| source down
+| A source is currently unavailable and cannot provide fresh data.
+| `Given the primary data source for live games is source down`
+|===

--- a/features/domain_requirements.feature
+++ b/features/domain_requirements.feature
@@ -17,10 +17,10 @@ Feature: Domain Rules - Sports Information Reliability and Transparency
     Given a game between "Cangrejeros" and "Vaqueros" is being played
     And a social media post reports the score as "75-70" for Cangrejeros
     And the official league website later reports the score as "76-70" for Cangrejeros
-    Then the two reports are considered conflicting
+    Then the two reports are considered conflicting reports
     And the official league report takes precedence
     And the conflicting social media report is recorded as unofficial
-    And fans should be made aware that a discrepancy existed
+    And fans should be made aware that conflicting reports existed
 
   # Req: R-DOM-4, R-DOM-1
   Scenario: Unverified report becomes confirmed
@@ -46,34 +46,34 @@ Feature: Domain Rules - Sports Information Reliability and Transparency
   Scenario: Multiple unofficial sources agree
     Given no official source has reported on a game
     And three different local news outlets all report the same score "65-60"
-    Then the score is considered likely accurate
+    Then the score is considered provisional
     And it may be treated as having medium confidence
-    But it is still marked as unverified until official confirmation
+    But it is still marked as provisional until official confirmation
     And all three sources are cited as the basis
 
   # Req: R-DOM-7
-  Scenario: Outdated game information
+  Scenario: Stale game information
     Given a game was played three days ago
     And no new reports have appeared since the initial score was posted
     Then that score is considered stale
-    And anyone consulting the record should be alerted that it may be outdated
+    And anyone consulting the record should be alerted that it may be stale
     And a refresh should be attempted by checking official sources again
 
   # Req: R-DOM-8, R-DOM-5
-  Scenario: Source becomes unavailable
+  Scenario: Source is marked as source down
     Given a particular news outlet has stopped publishing sports updates
-    Then that source is no longer considered active
-    And any information that depended solely on that source becomes less reliable
+    Then that source is considered source down
+    And any information that depended solely on that source becomes partial data
     And other sources must be used to verify past records
 
   # Req: R-DOM-2, R-DOM-1, R-DOM-3
   Scenario: Correction without formal announcement
     Given a score was reported as "77-76" in a local newspaper
     And days later the league website shows "78-76" with no correction notice
-    Then a conflict exists between the newspaper and the league
+    Then conflicting reports exist between the newspaper and the league
     And the league's version is considered authoritative
     And the newspaper's version is noted as a likely error
-    But if no official source exists, the conflict remains unresolved
+    But if no official source exists, the conflicting reports remain unresolved
 
   # Req: R-DOM-1, R-DOM-4, R-DOM-6
   Scenario: High demand for accurate information during playoffs

--- a/features/interface_requirements.feature
+++ b/features/interface_requirements.feature
@@ -21,12 +21,12 @@ Feature: User Interface - Transparency Indicators and Messaging
     And the staleness threshold for live games is "30 minutes"
     When Sebastian views the game details page
     Then Sebastian should see a "Stale" badge next to the score
-    And Sebastian should see an explanation about possible outdated data
+    And Sebastian should see an explanation about possible stale data
     And the stale indicator should use a muted color scheme
 
   # Req: R-DOM-2, R-DOM-3, R-INT-9
   Scenario: Show conflicting reports from different sources
-    Given two sources disagree on the score for this game
+    Given two sources provide conflicting reports for the score in this game
     And source "BSN Official" reports "82-75"
     And source "Twitter Feed" reports "81-75"
     When Sebastian views the game details page
@@ -66,10 +66,10 @@ Feature: User Interface - Transparency Indicators and Messaging
 
   # Req: R-MAC-9, R-INT-8
   Scenario: Communicate system-wide degraded state
-    Given the primary data source for live games is offline
+    Given the primary data source for live games is source down
     And cached scores are available from previous updates
     When Sebastian visits the home page
-    Then Sebastian should see a banner about delayed live updates
+    Then Sebastian should see a banner that the source is down and live updates show partial data
     And Sebastian should still see cached scores from previous updates
     And Sebastian should be able to navigate to other parts of the app
     And the banner should remain visible until the source recovers
@@ -80,6 +80,6 @@ Feature: User Interface - Transparency Indicators and Messaging
     And all non-official sources agree on the score
     And no official source has confirmed
     When Sebastian views the game details
-    Then Sebastian should see a confidence indicator about multiple sources agreeing
+    Then Sebastian should see a provisional confidence indicator about multiple sources agreeing
     And the indicator should use a caution color
     And Sebastian should understand this is not officially confirmed

--- a/features/machine_requirements.feature
+++ b/features/machine_requirements.feature
@@ -12,7 +12,7 @@ Feature: Machine-Level - Resilience, Logging, and Performance
     And the system has a timeout for each source fetch
 
   # Req: R-MAC-9, R-MAC-7
-  Scenario: Continue operating when a source fails
+  Scenario: Continue operating when a source is down
     Given source "BSN API" returns a 500 Internal Server Error
     When the system processes requests for data
     Then the system should not crash
@@ -22,8 +22,8 @@ Feature: Machine-Level - Resilience, Logging, and Performance
     And the system should return HTTP 200 to the user with available data
 
   # Req: R-MAC-9, R-DOM-7
-  Scenario: Fall back to cached data during source unavailability
-    Given source "Twitter API" has been unavailable for "2 minutes"
+  Scenario: Fall back to cached data during source down
+    Given source "Twitter API" has been marked source down for "2 minutes"
     And the last successful fetch from "Twitter API" returned valid data
     When a request requires data from source "Twitter API"
     Then the system should return the last successfully fetched value
@@ -32,12 +32,12 @@ Feature: Machine-Level - Resilience, Logging, and Performance
     And the system should mark the data appropriately based on staleness
 
   # Req: R-DOM-11, R-MAC-7
-  Scenario: Log conflicts for debugging and analysis
-    Given a conflict is detected between source "BSN API" and source "Twitter API"
-    And the conflict involves entity "GAME-123"
+  Scenario: Log conflicting reports for debugging and analysis
+    Given conflicting reports are detected between source "BSN API" and source "Twitter API"
+    And the conflicting reports involve entity "GAME-123"
     And source "BSN API" reports "75-70"
     And source "Twitter API" reports "76-70"
-    When the system records the conflict
+    When the system records the conflicting reports
     Then the system should create a log entry
     And the log entry should contain the entity ID
     And the log entry should contain both reported values
@@ -59,7 +59,7 @@ Feature: Machine-Level - Resilience, Logging, and Performance
 
   # Req: R-DOM-8, R-INT-8
   Scenario: Resume normal operation after source recovery
-    Given source "News Feed" was marked "down" for "10 minutes"
+    Given source "News Feed" was marked "source down" for "10 minutes"
     And source "News Feed" becomes responsive again
     And the system successfully fetches data from it
     When the system updates source health status


### PR DESCRIPTION
## Overview

Standardizes reliability-related wording across the current BDD scenarios and documentation.

## Key Changes

* Added a glossary section defining the approved reliability terms: `stale`, `provisional`, `conflicting reports`, `partial data`, and `source down`.
* Updated domain, interface, and machine-level feature scenarios to use those terms consistently.
* Replaced mixed wording such as “outdated,” “offline,” “unavailable,” “conflict,” and “likely accurate” with the canonical reliability language.
* Improved consistency between scenario wording and the project’s reliability-first terminology.

## Impact

This PR does not change application code. It improves documentation and BDD clarity so reliability states are described consistently across the project.

Related issue: #332
